### PR TITLE
feat(blog): add optional slug field to content schema

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,6 +7,7 @@ const blog = defineCollection({
     pubDate: z.coerce.date(),
     tags: z.array(z.string()).default([]),
     draft: z.boolean().default(false),
+    slug: z.string().optional(),
     description: z.string().optional(),
     image: z.string().optional(),
     lang: z.string().optional(),


### PR DESCRIPTION
Add `slug: z.string().optional()` to the blog content collection schema, so frontmatter slug can override the filesystem-based URL path.

Also updated 7 draft issues (#56, #57, #60, #61, #63, #66, #68) with English slugs in their frontmatter, enabling clean English URL paths for Chinese-titled posts.